### PR TITLE
Implemented new scripts for update 4.1

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,2 +1,3 @@
 * Michael Barrett (https://github.com/twisterghost)
 * Thijs Miedema (https://github.com/thijsmie)
+* Zack Strickland (https://github.com/trouvant)

--- a/src/scripts/_chunk/_chunk.gml
+++ b/src/scripts/_chunk/_chunk.gml
@@ -1,0 +1,30 @@
+/// @func _chunk(array, size)
+/// @desc Creates a two-dimensional array of elements split into groups of given length.
+/// @param {Array} array The array to split
+/// @param {Integer} size The size of each chunk
+/// @returns {Array} The two-dimensional array of chunks
+/*
+@example
+var arr = _arrayOf(0, 1, 2, 3);
+_chunk(arr, 2);
+// => [[0, 1], [2, 3]];
+
+var arr = _arrayOf(0, 1, 2, 3);
+_chunk(arr, 3);
+// => [[0, 1, 2], [3]];
+*/
+
+if (argument_count != 2) return false;
+if (argument1 == 0) return _arrayOf();
+
+var i;
+var _len;
+var __chunk;
+
+_len = array_length_1d(argument0);
+
+for (i = 0; i < _len; i++) {
+    __chunk[i div argument1, i mod argument1] = argument0[i];
+}
+
+return __chunk;

--- a/src/scripts/_chunk/_chunk.yy
+++ b/src/scripts/_chunk/_chunk.yy
@@ -1,8 +1,8 @@
 {
-    "id": "a6b523a8-9863-4b43-b7d2-d0490d07f636",
+    "id": "30814abc-08cb-429f-91b8-352de81acdc3",
     "modelName": "GMScript",
     "mvc": "1.0",
-    "name": "_reverse",
+    "name": "_chunk",
     "IsCompatibility": false,
     "IsDnD": false
 }

--- a/src/scripts/_difference/_difference.gml
+++ b/src/scripts/_difference/_difference.gml
@@ -1,0 +1,50 @@
+/// @func _difference(array, [arrays])
+/// @desc Creates an array of values from the first array not found in the other arrays.
+/// @param {Array} array The array to inspect
+/// @param {Array} [arrays] The arrays whose values are to be excluded
+/// @returns {Array} The difference between the first and the remaining arrays
+/*
+@example
+var arr0 = _array_of(0, 1, 2);
+var arr1 = _array_of(0);
+var arr2 = _array_of(0, 2);
+_difference(arr0, arr1, arr2);
+// => [1];
+*/
+
+if (argument_count == 0) return array_create(0);
+if (argument_count == 1) return argument[0];
+
+var i;
+var j;
+var n;
+var _arr;
+var _len;
+var _set;
+var __diff;
+
+_set = ds_map_create();
+
+for (i = 1; i < argument_count; i++) {
+    _arr = argument[i];
+    _len = array_length_1d(_arr);
+    for (j = 0; j < _len; j++) {
+        if (_set[? _arr[j]] != 1) {
+            _set[? _arr[j]] = 1;
+        }
+    }
+}
+
+n = 0;
+_arr = argument[0];
+_len = array_length_1d(_arr);
+__diff = array_create(0);
+
+for (i = 0; i < _len; i++) {
+	if (_set[? _arr[i]] != 1) {
+		__diff[n++] = _arr[i];	
+	}
+}
+
+ds_map_destroy(_set);
+return __diff;

--- a/src/scripts/_difference/_difference.yy
+++ b/src/scripts/_difference/_difference.yy
@@ -1,8 +1,8 @@
 {
-    "id": "a6b523a8-9863-4b43-b7d2-d0490d07f636",
+    "id": "cabfe734-b23d-4024-9089-eece7d748037",
     "modelName": "GMScript",
     "mvc": "1.0",
-    "name": "_reverse",
+    "name": "_difference",
     "IsCompatibility": false,
     "IsDnD": false
 }

--- a/src/scripts/_difference_by/_difference_by.gml
+++ b/src/scripts/_difference_by/_difference_by.gml
@@ -1,0 +1,59 @@
+/// @func _difference_by(array, [arrays], iteratee)
+/// @desc Like _difference(), except that it accepts iteratee which is invoked for each element of each array to generate the criterion by which they are compared.
+/// @param {Array} array The array to inspect
+/// @param {Array} [arrays] The arrays whose values are to be excluded
+/// @param {Script} iteratee The script invoked on each element to generate comparison criteria
+/// @returns {Array} The difference between the first and the remaining arrays
+/*
+@example
+// _floor(x)
+return floor(x);
+
+var arr0 = _array_of(0.5, 1, 2);
+var arr1 = _array_of(0);
+var arr2 = _array_of(0.1, 2.9);
+_difference_by(arr0, arr1, arr2, _floor);
+// => [1];
+*/
+
+if (argument_count == 0) return array_create(0);
+if (argument_count == 1) return argument[0];
+
+var i;
+var j;
+var n;
+var _arr;
+var _crit;
+var _iter;
+var _len;
+var _set;
+var __diff;
+
+_iter = argument[argument_count - 1];
+_set  = ds_map_create();
+
+for (i = 1; i < argument_count; i++) {
+    _arr = argument[i];
+    _len = array_length_1d(_arr);
+    for (j = 0; j < _len; j++) {
+		_crit = script_execute(_iter, _arr[j]);
+        if (_set[? _crit] != 1) {
+            _set[? _crit] = 1;
+        }
+    }
+}
+
+n = 0;
+_arr = argument[0];
+_len = array_length_1d(_arr);
+__diff = array_create(0);
+
+for (i = 0; i < _len; i++) {
+	_crit = script_execute(_iter, _arr[i]);
+	if (_set[? _crit] != 1) {
+		__diff[n++] = _arr[i];	
+	}
+}
+
+ds_map_destroy(_set);
+return __diff;

--- a/src/scripts/_difference_by/_difference_by.yy
+++ b/src/scripts/_difference_by/_difference_by.yy
@@ -1,8 +1,8 @@
 {
-    "id": "a6b523a8-9863-4b43-b7d2-d0490d07f636",
+    "id": "5c31d4b3-4c1b-4687-982e-40832d3e8148",
     "modelName": "GMScript",
     "mvc": "1.0",
-    "name": "_reverse",
+    "name": "_difference_by",
     "IsCompatibility": false,
     "IsDnD": false
 }

--- a/src/scripts/_drop/_drop.gml
+++ b/src/scripts/_drop/_drop.gml
@@ -1,0 +1,32 @@
+/// @func _drop(array, n)
+/// @desc Creates a slice of array with n elements dropped from the beginning.
+/// @param {Array} array The array to inspect
+/// @param {Integer} n The number of elements to drop
+/// @returns {Array} The slice of array
+/*
+@example
+var arr = _array_of(0, 1, 2, 3);
+_drop(arr, 2);
+// => [2, 3];
+*/
+
+if (argument1 == 0) return argument0;
+
+var i;
+var n;
+var _arr;
+var _len;
+var _num;
+var __drop;
+
+n = 0;
+_arr = argument0;
+_len = array_length_1d(_arr);
+_num = argument1;
+__drop = array_create(clamp(_len - _num, 0, _len));
+
+for (i = _num; i < _len; i++) {
+	__drop[n++] = _arr[i];
+}
+
+return __drop;

--- a/src/scripts/_drop/_drop.yy
+++ b/src/scripts/_drop/_drop.yy
@@ -1,8 +1,8 @@
 {
-    "id": "a6b523a8-9863-4b43-b7d2-d0490d07f636",
+    "id": "ad183422-6cc2-41f7-b74f-76e5e32b1fe7",
     "modelName": "GMScript",
     "mvc": "1.0",
-    "name": "_reverse",
+    "name": "_drop",
     "IsCompatibility": false,
     "IsDnD": false
 }

--- a/src/scripts/_drop_right/_drop_right.gml
+++ b/src/scripts/_drop_right/_drop_right.gml
@@ -1,0 +1,30 @@
+/// @func _drop_right(array, n)
+/// @desc Creates a slice of array with n elements dropped from the end.
+/// @param {Array} array The array to inspect
+/// @param {Integer} n The number of elements to drop
+/// @returns {Array} The slice of array
+/*
+@example
+var arr = _array_of(0, 1, 2, 3);
+_drop_right(arr, 2);
+// => [0, 1];
+*/
+
+if (argument1 == 0) return argument0;
+
+var i;
+var n;
+var _arr;
+var _len;
+var __drop;
+
+n = 0;
+_arr = argument0;
+_len = array_length_1d(_arr) - argument1;
+__drop = array_create(max(_len, 0));
+
+for (i = 0; i < _len; i++) {
+	__drop[n++] = _arr[i];
+}
+
+return __drop;

--- a/src/scripts/_drop_right/_drop_right.yy
+++ b/src/scripts/_drop_right/_drop_right.yy
@@ -1,8 +1,8 @@
 {
-    "id": "a6b523a8-9863-4b43-b7d2-d0490d07f636",
+    "id": "a2848a7b-0ac5-43b6-9310-fa3bdae189ee",
     "modelName": "GMScript",
     "mvc": "1.0",
-    "name": "_reverse",
+    "name": "_drop_right",
     "IsCompatibility": false,
     "IsDnD": false
 }

--- a/src/scripts/_fill/_fill.gml
+++ b/src/scripts/_fill/_fill.gml
@@ -1,0 +1,38 @@
+/// @func _fill(array, value, [start], [end])
+/// @desc Fills elements of array with value from start up to, but not including, end.
+/// @param {Array} array The array to fill
+/// @param {*} value The value with which to fill elements of array
+/// @param {Integer} [start] The start index
+/// @param {Integer} [end] The end index
+/// @returns {Array} The filled array
+/// @note This method mutates array.
+/*
+@example
+var arr = _arrayOf(0, 1, 2, 3);
+_fill(arr, 4, 1, 3);
+// => [0, 4, 4, 3];
+
+var arr = _arrayOf(0, 1, 2, 3);
+_fill(arr, 0);
+// => [0, 0, 0, 0];
+*/
+
+var i;
+var _arr;
+var _end;
+
+if (argument_count == 2) {
+    i    = 0;
+    _end = array_length_1d(argument[0]);
+} else if (argument_count == 4) {
+    i    = argument[2];
+    _end = argument[3];
+} else return false;
+
+_arr = argument[0];
+
+for (; i < _end; i++) {
+    _arr[@ i] = argument[1];
+}
+
+return _arr;

--- a/src/scripts/_fill/_fill.yy
+++ b/src/scripts/_fill/_fill.yy
@@ -1,8 +1,8 @@
 {
-    "id": "a6b523a8-9863-4b43-b7d2-d0490d07f636",
+    "id": "6d89431c-c6b2-444d-92a6-709d7a0e21f8",
     "modelName": "GMScript",
     "mvc": "1.0",
-    "name": "_reverse",
+    "name": "_fill",
     "IsCompatibility": false,
     "IsDnD": false
 }

--- a/src/scripts/_intersection/_intersection.gml
+++ b/src/scripts/_intersection/_intersection.gml
@@ -1,0 +1,54 @@
+/// @func _intersection([arrays])
+/// @desc Creates an array of unique values common to all given arrays in the order in which they originally appeared.
+/// @param {Array} [arrays] The remaining arrays to be intersected
+/// @returns {Array} The intersection of the given arrays
+/*
+@example
+var arr0 = _array_of(0, 1);
+var arr1 = _array_of(0);
+_intersection(arr0, arr1);
+// => [0];
+
+var arr0 = _array_of('Sword', 'Potion');
+var arr1 = _array_of('Shield', 'Potion', 'Sword');
+_intersection(arr0, arr1);
+// => ['Sword', 'Potion'];
+*/
+
+if (argument_count == 0) return array_create(0);
+if (argument_count == 1) return argument[0];
+
+var i;
+var j;
+var n;
+var _arr;
+var _len;
+var _set;
+var __intersection;
+
+_set = ds_map_create();
+
+for (i = 1; i < argument_count; i++) {
+    _arr = argument[i];
+    _len = array_length_1d(_arr);
+    for (j = 0; j < _len; j++) {
+        if (i == 1 || set[? _arr[j]] == i - 1) {
+            _set[? _arr[j]] = i;
+        }
+    }
+}
+
+n    = 0;
+_arr = argument[0];
+_len = array_length_1d(_arr);
+__intersection = array_create(0);
+
+for (i = 0; i < _len; i++) {
+    if (_set[? _arr[i]] == argument_count - 1) {
+        _set[? _arr[i]]++;
+        __intersection[n++] = _arr[i];
+    }
+}
+
+ds_map_destroy(_set);
+return __intersection;

--- a/src/scripts/_intersection/_intersection.yy
+++ b/src/scripts/_intersection/_intersection.yy
@@ -1,8 +1,8 @@
 {
-    "id": "a6b523a8-9863-4b43-b7d2-d0490d07f636",
+    "id": "81c329de-8b88-4780-91cf-0bd3ee674f78",
     "modelName": "GMScript",
     "mvc": "1.0",
-    "name": "_reverse",
+    "name": "_intersection",
     "IsCompatibility": false,
     "IsDnD": false
 }

--- a/src/scripts/_intersection_by/_intersection_by.gml
+++ b/src/scripts/_intersection_by/_intersection_by.gml
@@ -1,0 +1,58 @@
+/// @func _intersection_by([arrays], iteratee)
+/// @desc Like _intersection(), except that it accepts iteratee which is invoked for each element of each array to generate the criterion by which uniqueness is computed.
+/// @param {Array} [arrays] The arrays to be intersected
+/// @param {Script} iteratee The script invoked on each element to generate uniqueness criteria
+/// @returns {Array} The intersection of the given arrays
+/*
+@example
+// _floor(x)
+return floor(x);
+
+var arr0 = _array_of(0, 1.9);
+var arr1 = _array_of(0.6, 3);
+_intersection_by(arr0, arr1, _floor);
+// => [0];
+*/
+
+if (argument_count == 0) return array_create(0);
+if (argument_count == 1) return argument[0];
+
+var i;
+var j;
+var n;
+var _arr;
+var _crit;
+var _iter;
+var _len;
+var _set;
+var __intersection;
+
+_iter = argument[argument_count - 1];
+_set = ds_map_create();
+
+for (i = 1; i < argument_count; i++) {
+    _arr = argument[i];
+    _len = array_length_1d(_arr);
+    for (j = 0; j < _len; j++) {
+		_crit = script_execute(_iter, _arr[j]);
+        if (i == 1 || set[? _crit] == i - 1) {
+            _set[? _crit] = i;
+        }
+    }
+}
+
+n    = 0;
+_arr = argument[0];
+_len = array_length_1d(_arr);
+__intersection = array_create(0);
+
+for (i = 0; i < _len; i++) {
+	_crit = script_execute(_iter, _arr[i]);
+    if (_set[? _crit] == argument_count - 2) {
+        _set[? _crit]++;
+        __intersection[n++] = _arr[i];
+    }
+}
+
+ds_map_destroy(_set);
+return __intersection;

--- a/src/scripts/_intersection_by/_intersection_by.yy
+++ b/src/scripts/_intersection_by/_intersection_by.yy
@@ -1,8 +1,8 @@
 {
-    "id": "a6b523a8-9863-4b43-b7d2-d0490d07f636",
+    "id": "29c5c198-489e-44d7-8492-800559d1e396",
     "modelName": "GMScript",
     "mvc": "1.0",
-    "name": "_reverse",
+    "name": "_intersection_by",
     "IsCompatibility": false,
     "IsDnD": false
 }

--- a/src/scripts/_reverse/_reverse.gml
+++ b/src/scripts/_reverse/_reverse.gml
@@ -1,19 +1,29 @@
 /// @func _reverse(array)
-/// @desc Reverses a given input array
-/// @param {Array} array The array to reverse
+/// @desc Reverses the order of elements in a given array.
+/// @param {Array} array The array to modify
 /// @returns {Array} The reversed array
+/// @note This method mutates array.
 /*
 @example
-var myArray = [1, 2, 3];
-var reverseArray = _reverse(myArray);
-// => [3, 2, 1]
+var arr = _array_of(0, 1, 2);
+_reverse(arr);
+// => [2, 1, 0];
 */
 
-var result;
-var n = array_length_1d(argument0);
+var i;
+var _arr;
+var _half;
+var _len;
+var _tmp;
 
-for (var i = 0; i < n; i++) {
-	result[i] = argument0[@ n-1-i];
+_arr = argument0;
+_len = array_length_1d(_arr);
+_half = floor(_len / 2);
+
+for (i = 0; i < _half; i++) {
+	_tmp = _arr[@ i];
+	_arr[@ i] = _arr[@ _len - 1 - i];
+	_arr[@ _len - 1 - i] = _tmp;
 }
 
-return result;
+return _arr;

--- a/src/scripts/_union/_union.gml
+++ b/src/scripts/_union/_union.gml
@@ -1,0 +1,45 @@
+/// @func _union([arrays])
+/// @desc Creates an array of unique values, in the order in which they originally appeared, from all given arrays.
+/// @param {Array} [arrays] The arrays to be unioned
+/// @returns {Array} The union of the given arrays
+/*
+@example
+var arr0 = _arrayOf(0, 1);
+var arr1 = _arrayOf(0);
+_union(arr0, arr1);
+// => [0, 1];
+
+var arr0 = _arrayOf('Sword', 'Potion');
+var arr1 = _arrayOf('Shield', 'Sword');
+_union(arr0, arr1);
+// => ['Sword', 'Potion', 'Shield'];
+*/
+
+if (argument_count == 0) return array_create(0);
+if (argument_count == 1) return argument[0];
+
+var i;
+var j;
+var n;
+var _arr;
+var _len;
+var _set;
+var __union;
+
+n = 0;
+_set = ds_map_create();
+__union = array_create(0);
+
+for (i = 0; i < argument_count; i++) {
+    _arr = argument[i];
+    _len = array_length_1d(_arr);
+    for (j = 0; j < _len; j++) {
+        if (_set[? _arr[j]] != 1) {
+            _set[? _arr[j]] = 1;
+            __union[n++] = _arr[j];
+        }
+    }
+}
+
+ds_map_destroy(_set);
+return __union;

--- a/src/scripts/_union/_union.yy
+++ b/src/scripts/_union/_union.yy
@@ -1,8 +1,8 @@
 {
-    "id": "a6b523a8-9863-4b43-b7d2-d0490d07f636",
+    "id": "120574fd-7f32-42b6-a7bd-bd1d337eda3a",
     "modelName": "GMScript",
     "mvc": "1.0",
-    "name": "_reverse",
+    "name": "_union",
     "IsCompatibility": false,
     "IsDnD": false
 }

--- a/src/scripts/_union_by/_union_by.gml
+++ b/src/scripts/_union_by/_union_by.gml
@@ -1,0 +1,48 @@
+/// @func _union_by([arrays], iteratee)
+/// @desc Like _union(), except that it accepts iteratee which is invoked for each element of each array to generate the criterion by which uniqueness is computed.
+/// @param {Array} [arrays] The arrays to be unioned
+/// @param {Script} iteratee The script invoked on each element to generate uniqueness criteria
+/// @returns {Array} The union of the given arrays
+/*
+@example
+// _floor(x)
+return floor(x);
+
+var arr0 = _arrayOf(0.5, 1.2);
+var arr1 = _arrayOf(0, 1.9);
+_union_by(arr0, arr1, _floor);
+// => [0.5, 1.2];
+*/
+
+if (argument_count == 0) return array_create(0);
+if (argument_count == 1) return argument[0];
+
+var i;
+var j;
+var n;
+var _arr;
+var _crit;
+var _iter;
+var _len;
+var _set;
+var __union;
+
+n = 0;
+_iter = argument[argument_count - 1];
+_set  = ds_map_create();
+__union = array_create(0);
+
+for (i = 0; i < argument_count; i++) {
+    _arr = argument[i];
+    _len = array_length_1d(_arr);
+    for (j = 0; j < _len; j++) {
+		_crit = script_execute(_iter, _arr[j]);
+        if (_set[? _crit] != 1) {
+            _set[? _crit] = 1;
+            __union[n++] = _arr[j];
+        }
+    }
+}
+
+ds_map_destroy(_set);
+return __union;

--- a/src/scripts/_union_by/_union_by.yy
+++ b/src/scripts/_union_by/_union_by.yy
@@ -1,8 +1,8 @@
 {
-    "id": "a6b523a8-9863-4b43-b7d2-d0490d07f636",
+    "id": "aaddf501-f581-440e-a652-6eb79cb6b4ec",
     "modelName": "GMScript",
     "mvc": "1.0",
-    "name": "_reverse",
+    "name": "_union_by",
     "IsCompatibility": false,
     "IsDnD": false
 }

--- a/src/scripts/_unzip/_unzip.gml
+++ b/src/scripts/_unzip/_unzip.gml
@@ -1,0 +1,34 @@
+/// @func _unzip(array)
+/// @desc From a zipped two-dimensional array, creates a collection of grouped elements by regrouping the elements to their pre-zipped configuration 
+/// @param {Array} array The zipped two-dimensional array
+/// @returns {Array} The two-dimensional array of regrouped elements
+/*
+@example
+var arr0 = _arrayOf(0, 1, 2);
+var arr1 = _arrayOf(3, 4, 5);
+var arr2 =_zip(arr0, arr1);
+_unzip(arr2);
+// => [[0, 1, 2], [3, 4, 5]];
+
+*/
+
+if (argument_count != 1) return array_create(0);
+
+var i;
+var j;
+var _len;
+var _num;
+var __unzip;
+
+_len = array_length_1d(argument0);
+_num = array_length_2d(argument0, 0);
+__unzip = array_create(_num);
+
+for (i = 0; i < _num; i++) {
+    for (j = 0; j < _len; j++) {
+        if (j >= array_length_2d(argument0, i)) continue;
+        __unzip[i, j] = argument0[j, i];
+    }
+}
+
+return __unzip;

--- a/src/scripts/_unzip/_unzip.yy
+++ b/src/scripts/_unzip/_unzip.yy
@@ -1,8 +1,8 @@
 {
-    "id": "a6b523a8-9863-4b43-b7d2-d0490d07f636",
+    "id": "e2bca758-18d1-400f-8fe0-7a3d77d83655",
     "modelName": "GMScript",
     "mvc": "1.0",
-    "name": "_reverse",
+    "name": "_unzip",
     "IsCompatibility": false,
     "IsDnD": false
 }

--- a/src/scripts/_without/_without.gml
+++ b/src/scripts/_without/_without.gml
@@ -1,0 +1,41 @@
+/// @func _without(array, [values])
+/// @desc Creates an array excluding all given values from amongst the elements of the given array
+/// @param {Array} array The array to inspect
+/// @param {*} [values] The values to exclude
+/// @returns {Array} The array of filtered elements
+/*
+@example
+var arr = _array_of(0, 1, 0, 2);
+_without(arr, 0, 1);
+// => [2];
+*/
+
+if (argument_count == 0) return array_create(0);
+if (argument_count == 1) return argument[0];
+
+var i;
+var j;
+var n;
+var _arr;
+var _match;
+var _len;
+var __without;
+
+n = 0;
+_arr = argument[0];
+_len = array_length_1d(_arr);
+__without = array_create(0);
+
+for (i = 0; i < _len; i++) {
+	_match = false;
+	for (j = 1; j < argument_count; j++) {
+		if (_arr[i] == argument[j]) {
+			_match = true;
+		}
+	}
+	if (!_match) {
+		__without[n++] = _arr[i];
+	}
+}
+
+return __without;

--- a/src/scripts/_without/_without.yy
+++ b/src/scripts/_without/_without.yy
@@ -1,8 +1,8 @@
 {
-    "id": "a6b523a8-9863-4b43-b7d2-d0490d07f636",
+    "id": "8d8a9d6e-af78-4037-9e5b-a78bdc24dcac",
     "modelName": "GMScript",
     "mvc": "1.0",
-    "name": "_reverse",
+    "name": "_without",
     "IsCompatibility": false,
     "IsDnD": false
 }

--- a/src/scripts/_zip/_zip.gml
+++ b/src/scripts/_zip/_zip.gml
@@ -1,0 +1,40 @@
+/// @func _zip([arrays])
+/// @desc Creates a two-dimensional array of grouped elements, the first of which contains the first elements of the given arrays, the second of which contains the second elements of the given arrays, and so on.
+/// @param {Array} [arrays] The remaining arrays
+/// @returns {Array} The array of elements grouped in arrays
+/*
+@example
+var arr0 = _arrayOf(0, 1);
+var arr1 = _arrayOf('Sword', 'Shield');
+var arr2 = _arrayOf(true, false);
+_zip(arr0, arr1, arr2);
+// => [[0, 'Sword', true], [1, 'Shield', false]];
+
+var arr0 = _arrayOf(0, 1, 2);
+var arr1 = _arrayOf(3, 4, 5);
+_zip(arr0, arr1);
+// => [[0, 3], [1, 4], [2, 5]];
+*/
+
+if (argument_count == 0) return array_create(0);
+
+var i;
+var j;
+var _arr;
+var _len;
+var __zip;
+
+_len = array_length_1d(argument[0]);
+for (i = 1; i < argument_count; i++)
+    _len = max(_len, array_length_1d(argument[i]));
+__zip = array_create(0);
+    
+for (i = 0; i < _len; i++) {
+    for (j = 0; j < argument_count; j++) {
+        _arr = argument[j];        
+        if (i >= array_length_1d(_arr)) continue;
+        __zip[i, j] = _arr[i];
+    }
+}
+
+return __zip;

--- a/src/scripts/_zip/_zip.yy
+++ b/src/scripts/_zip/_zip.yy
@@ -1,8 +1,8 @@
 {
-    "id": "a6b523a8-9863-4b43-b7d2-d0490d07f636",
+    "id": "0ed1f92e-cf2d-4dda-9ea7-6b290b55eaf0",
     "modelName": "GMScript",
     "mvc": "1.0",
-    "name": "_reverse",
+    "name": "_zip",
     "IsCompatibility": false,
     "IsDnD": false
 }


### PR DESCRIPTION
Resolves #9.

Note that I chose not to implement _pull(), for, unless I'm mistaken, it wouldn't work well with GML in its present form. The problem stems from the lack of support for resizing an array except to expand it, and without any way to directly access the memory on the heap associated with an array, it appears to me impossible to contract an array to the appropriate size once elements are removed. One should use _without() or, preferably, ds_lists for similar behaviour.